### PR TITLE
docs: remove Tebi S3 from backup providers

### DIFF
--- a/manage/backup.md
+++ b/manage/backup.md
@@ -206,23 +206,6 @@ Settings to use on _PikaPods_:
 - **S3 Access Key ID**: The Access Key ID from your generated API key
 - **S3 Secret Key**: The Secret Key from your generated API key
 
-#### **[Tebi S3](https://tebi.io/)**
-
-A European S3-compatible storage solution (based in Cyprus) with a generous free tier offering 50 GB total storage (25 GB of data in 2 copies). Offers unlimited pay-as-you-go plans with no credit card needed to get started. Includes 250 GB of free outbound transfer.
-
-Setup Steps in Tebi:
-
-1. Create an account and set up a bucket for your backups
-2. Generate access keys for your bucket
-3. Save both the Access Key ID and Secret Key
-
-Settings to use on _PikaPods_:
-
-- **S3 Endpoint**: `s3.tebi.io`
-- **Bucket**: Your bucket name
-- **S3 Access Key ID**: The Access Key ID from your generated key
-- **S3 Secret Key**: The Secret Key from your generated key
-
 #### **[MEGA S4](https://mega.io/objectstorage)**
 
 MEGA's S3-compatible object storage service with multiple regional endpoints. Offers competitive pricing and strong privacy focus.


### PR DESCRIPTION
Tebi S3 is shutting down soon. This PR removes it from the list of recommended S3 storage providers in the backup documentation to avoid misleading users.